### PR TITLE
Restore Mario's and Luigi's position in nextLevel function

### DIFF
--- a/games/mariobros/js/mariobros.js
+++ b/games/mariobros/js/mariobros.js
@@ -223,7 +223,9 @@ mariobros.MainGame.prototype = {
 			this.dropcase[c].falling = false;
 			this.dropcase[c].frame = 0;
 		}
-
+		// resets positions
+		this.mariopos = 1;
+		this.luigipos = 0;
 		this.continueGame();
 	},
 


### PR DESCRIPTION
Once the truck is full and leaves, the game resumes but the position of Mario and Luigi remains the same. In my MW-56 the positions of the characters is reset so I included that change to the code.